### PR TITLE
Update go.mod to avoid module parse error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module contrib.go.opencensus.io/exporter/prometheus
+module contrib.go.opencensus.io/exporter/prometheus-pushgateway-exporter
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect


### PR DESCRIPTION
When I run `go get -u github.com/hqt/opencensus-pushgateway-exporter`, I get the following error:
```
go get: github.com/hqt/opencensus-pushgateway-exporter@none updating to
        github.com/hqt/opencensus-pushgateway-exporter@v0.1.0: parsing go.mod:
        module declares its path as: contrib.go.opencensus.io/exporter/prometheus
                but was required as: github.com/hqt/opencensus-pushgateway-exporter
```
I believe this change should fix this.